### PR TITLE
Added core functionality of hackathon registration

### DIFF
--- a/app/api/v1/team/create/route.ts
+++ b/app/api/v1/team/create/route.ts
@@ -1,0 +1,40 @@
+import { adminDb } from '@/firebase/admin';
+import { verifyToken } from '@/lib/verify-token';
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function POST(req: NextRequest) {
+    try {
+        const decoded = await verifyToken(req);
+        if (!decoded) return NextResponse.json({ error: 'Invalid token' }, { status: 401 });
+
+        const { uid, name } = decoded;
+
+        const teamData = await req.json();
+        const { team_name } = teamData;
+
+        const teamRef = adminDb.collection('teams').doc(uid);
+        const teamSnap = await teamRef.get();
+
+        if (!teamSnap.exists) {
+            await teamRef.set({
+                team_id: uid,
+                team_name: team_name,
+                team_leader: name,
+                peers: [],
+                drive_link: '',
+                createdAt: new Date().toISOString(),
+            });
+        }
+
+        const userRef = adminDb.collection('users').doc(uid);
+        await userRef.update({
+            team_id: uid,
+            updatedAt: new Date().toISOString(),
+        });
+
+        return NextResponse.json({ success: true, message: `Team ${uid} created successfully` });
+    } catch (err) {
+        console.error('API error:', err);
+        return NextResponse.json({ error: 'Server error' }, { status: 500 });
+    }
+}

--- a/app/api/v1/team/delete/route.ts
+++ b/app/api/v1/team/delete/route.ts
@@ -1,0 +1,42 @@
+import { adminDb } from '@/firebase/admin';
+import { verifyToken } from '@/lib/verify-token';
+import { NextRequest, NextResponse } from 'next/server';
+import { FieldValue } from 'firebase-admin/firestore';
+
+export async function POST(req: NextRequest) {
+    try {
+        const decoded = await verifyToken(req);
+        if (!decoded) return NextResponse.json({ error: 'Invalid token' }, { status: 401 });
+
+        const { uid, email, name, phone } = decoded;
+
+        const searchData = await req.json();
+        const { team_id } = searchData;
+
+        const teamRef = adminDb.collection('teams').doc(team_id);
+        await teamRef.update({
+            team_id: FieldValue.delete(),
+            team_name: FieldValue.delete(),
+            team_leader: FieldValue.delete(),
+            peers: FieldValue.delete(),
+            drive_link: FieldValue.delete(),
+            createdAt: FieldValue.delete(),
+        });
+
+        await teamRef.delete();
+
+        const userRef = adminDb.collection('users').doc(uid);
+        await userRef.update({
+            team_id: '',
+            updatedAt: new Date().toISOString(),
+        });
+
+        return NextResponse.json({
+            success: true,
+            message: `Team ${team_id} successfully`
+        });
+    } catch (err) {
+        console.error('API error:', err);
+        return NextResponse.json({ error: 'Server error' }, { status: 500 });
+    }
+}

--- a/app/api/v1/team/get/route.ts
+++ b/app/api/v1/team/get/route.ts
@@ -1,0 +1,49 @@
+import { adminDb } from '@/firebase/admin';
+import { verifyToken } from '@/lib/verify-token';
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function GET(req: NextRequest) {
+    try {
+        const decoded = await verifyToken(req);
+        if (!decoded) return NextResponse.json({ error: 'Invalid token' }, { status: 401 });
+
+        const { uid } = decoded;
+
+        // Check if team_id is provided as query parameter (optimization)
+        const url = new URL(req.url);
+        const teamIdParam = url.searchParams.get('team_id');
+
+        let teamId: string;
+
+        if (teamIdParam) {
+            teamId = teamIdParam;
+        } else {
+            const userRef = adminDb.collection('users').doc(uid);
+            const userSnap = await userRef.get();
+
+            if (!userSnap.exists) {
+                return NextResponse.json({ error: 'User profile not found' }, { status: 404 });
+            }
+
+            const userData = userSnap.data();
+            teamId = userData?.team_id;
+        }
+
+        if (!teamId || teamId === "") {
+            return NextResponse.json({ error: 'User is not part of any team' }, { status: 404 });
+        }
+
+        const teamRef = adminDb.collection('teams').doc(teamId);
+        const teamSnap = await teamRef.get();
+
+        if (!teamSnap.exists) {
+            return NextResponse.json({ error: 'Team not found' }, { status: 404 });
+        }
+
+        const teamData = teamSnap.data();
+        return NextResponse.json(teamData);
+    } catch (err) {
+        console.error('API error:', err);
+        return NextResponse.json({ error: 'Server error' }, { status: 500 });
+    }
+}

--- a/app/api/v1/team/join/route.ts
+++ b/app/api/v1/team/join/route.ts
@@ -1,0 +1,35 @@
+import { adminDb } from '@/firebase/admin';
+import { verifyToken } from '@/lib/verify-token';
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function POST(req: NextRequest) {
+  try {
+    const decoded = await verifyToken(req);
+    if (!decoded) return NextResponse.json({ error: 'Invalid token' }, { status: 401 });
+
+    const { uid, name } = decoded;
+
+    const searchData = await req.json();
+    const { team_id } = searchData;
+
+    const teamRef = adminDb.collection('teams').doc(team_id);
+    await teamRef.update({
+      peers: [{ id: uid, name: name }],
+      updatedAt: new Date().toISOString(),
+    });
+
+    const userRef = adminDb.collection('users').doc(uid);
+    await userRef.update({
+      team_id: team_id,
+      updatedAt: new Date().toISOString(),
+    });
+
+    return NextResponse.json({ 
+      success: true, 
+      message: `${uid} joined team ${team_id} successfully`
+    });
+  } catch (err) {
+    console.error('API error:', err);
+    return NextResponse.json({ error: 'Server error' }, { status: 500 });
+  }
+}

--- a/app/api/v1/team/leave/route.ts
+++ b/app/api/v1/team/leave/route.ts
@@ -1,0 +1,35 @@
+import { adminDb } from '@/firebase/admin';
+import { verifyToken } from '@/lib/verify-token';
+import { NextRequest, NextResponse } from 'next/server';
+import { FieldValue } from 'firebase-admin/firestore';
+
+export async function POST(req: NextRequest) {
+  try {
+    const decoded = await verifyToken(req);
+    if (!decoded) return NextResponse.json({ error: 'Invalid token' }, { status: 401 });
+
+    const { uid, email, name, phone } = decoded;
+
+    const searchData = await req.json();
+    const { team_id } = searchData;
+
+    const teamRef = adminDb.collection('teams').doc(team_id);
+    await teamRef.update({
+      peers: FieldValue.arrayRemove({ id: uid, name: name })
+    });
+
+    const userRef = adminDb.collection('users').doc(uid);
+    await userRef.update({
+      team_id: '',
+      updatedAt: new Date().toISOString(),
+    });
+
+    return NextResponse.json({ 
+      success: true, 
+      message: `${uid} left team ${team_id} successfully`
+    });
+  } catch (err) {
+    console.error('API error:', err);
+    return NextResponse.json({ error: 'Server error' }, { status: 500 });
+  }
+}

--- a/app/api/v1/team/remove/route.ts
+++ b/app/api/v1/team/remove/route.ts
@@ -1,0 +1,35 @@
+import { adminDb } from '@/firebase/admin';
+import { verifyToken } from '@/lib/verify-token';
+import { NextRequest, NextResponse } from 'next/server';
+import { FieldValue } from 'firebase-admin/firestore';
+
+export async function POST(req: NextRequest) {
+    try {
+        const decoded = await verifyToken(req);
+        if (!decoded) return NextResponse.json({ error: 'Invalid token' }, { status: 401 });
+
+        const { uid } = decoded;
+
+        const searchData = await req.json();
+        const { peer_id, peer_name } = searchData;
+
+        const teamRef = adminDb.collection('teams').doc(uid);
+        await teamRef.update({
+            peers: FieldValue.arrayRemove({ id: peer_id, name: peer_name })
+        });
+
+        const userRef = adminDb.collection('users').doc(peer_id);
+        await userRef.update({
+            team_id: '',
+            updatedAt: new Date().toISOString(),
+        });
+
+        return NextResponse.json({
+            success: true,
+            message: `${peer_id} removed from team ${uid} successfully`
+        });
+    } catch (err) {
+        console.error('API error:', err);
+        return NextResponse.json({ error: 'Server error' }, { status: 500 });
+    }
+}

--- a/app/api/v1/user/update/route.ts
+++ b/app/api/v1/user/update/route.ts
@@ -1,4 +1,5 @@
 import { adminDb } from '@/firebase/admin';
+import { adminAuth } from '@/firebase/admin';
 import { verifyToken } from '@/lib/verify-token';
 import { NextRequest, NextResponse } from 'next/server';
 
@@ -23,9 +24,23 @@ export async function POST(req: NextRequest) {
       updatedAt: new Date().toISOString(),
     });
 
+    // Update Firebase Auth displayName and custom claims
+    await adminAuth.updateUser(uid, {
+      displayName: name,
+    });
+
+    // Set custom claims with updated user data to refresh token
+    await adminAuth.setCustomUserClaims(uid, {
+      name: name,
+      email: email,
+      phone: phone,
+      updatedAt: new Date().toISOString()
+    });
+
     return NextResponse.json({ 
       success: true, 
-      message: 'Profile updated successfully' 
+      message: 'Profile updated successfully',
+      refreshToken: true // Signal client to refresh token
     });
   } catch (err) {
     console.error('API error:', err);

--- a/app/profile/hackathon/create/page.tsx
+++ b/app/profile/hackathon/create/page.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import {useEffect, useState} from "react";
+import {useAuth} from "@/context/AuthContext";
+import {Button} from "@/components/ui/button";
+import {Label} from "@/components/ui/label";
+import {Input} from "@/components/ui/input";
+import {useRouter} from "next/navigation";
+
+export default function HackathonCreateTeam() {
+    const router = useRouter();
+    const { user, loading, signOut, profile, profileLoading, setProfile, team, teamLoading, setTeam } = useAuth();
+    const [form, setForm] = useState({
+        team_name: '',
+    });
+
+    const [isCreating, setIsCreating] = useState(false);
+    const [create, setCreated] = useState(false);
+    const [isDirty, setIsDirty] = useState(false);
+    const [error, setError] = useState('');
+
+    const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+        e.preventDefault();
+        if (!user) return;
+
+        if (!form.team_name) {
+            setError('All fields are required.');
+            return;
+        }
+        setError('');
+
+        setIsCreating(true);
+        setCreated(false);
+
+        try {
+            // Force refresh token to get latest user claims (updated name)
+            const idToken = await user.getIdToken(true);
+            const res = await fetch('/api/v1/team/create', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'Authorization': `Bearer ${idToken}`,
+                },
+                body: JSON.stringify(form),
+            });
+
+            if (res.ok) {
+                setCreated(true);
+                setIsDirty(false);
+            }
+        } catch (error) {
+            console.error('Error creating team:', error);
+        } finally {
+            setIsCreating(false);
+            setTimeout(() => setCreated(false), 2000);
+        }
+    };
+
+    useEffect(() => {
+        if (create) {
+            const timer = setTimeout(() => {
+                router.push('/profile');
+            }, 1000);
+            return () => clearTimeout(timer);
+        }
+    }, [create, router]);
+
+  return (
+    <div className="flex flex-col items-center justify-center min-h-screen p-4 bg-gray-50">
+        <div className="bg-white rounded-lg shadow p-8">
+            <form className="flex flex-col justify-center items-center space-y-6 text-gray-900" onSubmit={handleSubmit}>
+                <div className="gap-6">
+                    <div>
+                        <Label htmlFor="team_name" className="mb-2">Team Name</Label>
+                        <Input
+                            id="team_name"
+                            type="text"
+                            value={form.team_name}
+                            onChange={(e) => {
+                                setForm({ ...form, team_name: e.target.value });
+                                setIsDirty(true);
+                            }}
+
+                            placeholder="Enter a team name"
+                            className="text-gray-900 placeholder:text-gray-500 border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                            required
+                        />
+                    </div>
+                </div>
+                {error && <p className="text-red-500 text-sm">{error}</p>}
+
+                <Button
+                    type="submit"
+                    className="bg-black hover:bg-black/70 text-white px-6 py-2 rounded-md transition-colors disabled:opacity-50 cursor-pointer"
+                    disabled={isCreating || create || !isDirty}
+                >
+                    {isCreating ? 'Creating...' : create ? 'Created!': 'Create'}
+                </Button>
+            </form>
+        </div>
+    </div>
+  );
+}

--- a/app/profile/hackathon/join/page.tsx
+++ b/app/profile/hackathon/join/page.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import {useEffect, useState} from "react";
+import {useAuth} from "@/context/AuthContext";
+import {Button} from "@/components/ui/button";
+import {Label} from "@/components/ui/label";
+import {Input} from "@/components/ui/input";
+import {useRouter} from "next/navigation";
+
+export default function HackathonJoinTeam() {
+    const router = useRouter();
+    const { user, loading, signOut, profile, profileLoading, setProfile, team, teamLoading, setTeam } = useAuth();
+    const [form, setForm] = useState({
+        team_id: '',
+    });
+
+    const [isJoining, setIsJoining] = useState(false);
+    const [join, setJoined] = useState(false);
+    const [isDirty, setIsDirty] = useState(false);
+    const [error, setError] = useState('');
+
+    const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+        e.preventDefault();
+        if (!user) return;
+
+        if (!form.team_id) {
+            setError('All fields are required.');
+            return;
+        }
+        setError('');
+
+        setIsJoining(true);
+        setJoined(false);
+
+        try {
+            // Force refresh token to get latest user claims (updated name)
+            const idToken = await user.getIdToken(true);
+            const res = await fetch('/api/v1/team/join', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'Authorization': `Bearer ${idToken}`,
+                },
+                body: JSON.stringify(form),
+            });
+
+            if (res.ok) {
+                setJoined(true);
+                setIsDirty(false);
+            }
+        } catch (error) {
+            console.error('Error joining team:', error);
+        } finally {
+            setIsJoining(false);
+            setTimeout(() => setJoined(false), 2000);
+        }
+    };
+
+    useEffect(() => {
+        if (join) {
+            const timer = setTimeout(() => {
+                router.push('/profile/hackathon');
+            }, 1000);
+            return () => clearTimeout(timer);
+        }
+    }, [join, router]);
+
+    return (
+        <div className="flex flex-col items-center justify-center min-h-screen p-4 bg-gray-50">
+            <div className="bg-white rounded-lg shadow p-8">
+                <form className="flex flex-col justify-center items-center space-y-6 text-gray-900" onSubmit={handleSubmit}>
+                    <div className="gap-6">
+                        <div>
+                            <Label htmlFor="team_id" className="mb-2">Team ID</Label>
+                            <Input
+                                id="team_id"
+                                type="text"
+                                value={form.team_id}
+                                onChange={(e) => {
+                                    setForm({ ...form, team_id: e.target.value });
+                                    setIsDirty(true);
+                                }}
+
+                                placeholder="Enter team ID"
+                                className="text-gray-900 placeholder:text-gray-500 border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                                required
+                            />
+                        </div>
+                    </div>
+                    {error && <p className="text-red-500 text-sm">{error}</p>}
+
+                    <Button
+                        type="submit"
+                        className="bg-black hover:bg-black/70 text-white px-6 py-2 rounded-md transition-colors disabled:opacity-50 cursor-pointer"
+                        disabled={isJoining || join || !isDirty}
+                    >
+                        {isJoining ? 'Joining...' : join ? 'Joined!': 'Join'}
+                    </Button>
+                </form>
+            </div>
+        </div>
+    );
+}

--- a/app/profile/hackathon/page.tsx
+++ b/app/profile/hackathon/page.tsx
@@ -1,9 +1,284 @@
+'use client';
+
+import {Button} from "@/components/ui/button";
+import Link from "next/link";
+import {useAuth} from "@/context/AuthContext";
+import {useEffect, useState} from "react";
+import {Label} from "@/components/ui/label";
+
 export default function HackathonPage() {
+    const { user, loading, profile, setProfile, team, teamLoading, setTeam } = useAuth();
+    const [isFormLoading, setIsFormLoading] = useState(false);
+    const [isLeaving, setIsLeaving] = useState(false);
+    const [leave, setLeave] = useState(false);
+    const [leaveTimer, setLeaveTimer] = useState<NodeJS.Timeout | null>(null);
+    const [form, setForm] = useState<{
+        team_id: string;
+        team_name: string;
+        team_leader: string;
+        peers: Array<{ id: string; name: string }>;
+        drive_link: string;
+    }>({
+        team_id: '',
+        team_name: '',
+        team_leader: '',
+        peers: [],
+        drive_link: '',
+    });
+
+    const handleRemovePeer = async (peer_id: string, peer_name: string) => {
+        if (!user) return;
+
+        setIsLeaving(true);
+
+        try {
+            const idToken = await user.getIdToken(true);
+            const res = await fetch('/api/v1/team/remove', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'Authorization': `Bearer ${idToken}`,
+                },
+                body: JSON.stringify({peer_id: peer_id, peer_name: peer_name}),
+            });
+
+            if (res.ok) {
+                setTeam(null);
+                setProfile({...profile, team_id: ''});
+                setLeave(true);
+
+            } else {
+                const errorData = await res.json();
+                console.log(errorData.error || 'Failed to remove team');
+            }
+        } catch (error) {
+            console.error('Error removing from team:', error);
+            console.log('An error occurred while removing from the team');
+        } finally {
+            setIsLeaving(false);
+
+            // Clear any existing timer
+            if (leaveTimer) {
+                clearTimeout(leaveTimer);
+            }
+
+            // Set delay for leaving state with proper cleanup
+            const timer = setTimeout(() => {
+                setLeave(false);
+                setLeaveTimer(null);
+                // Refresh the page to show updated state instead of router.push
+                window.location.reload();
+            }, 2000);
+
+            setLeaveTimer(timer);
+        }
+    }
+
+    const handleDeleteTeam = async () => {
+        if (!user) return;
+
+        setIsLeaving(true);
+
+        try {
+            const idToken = await user.getIdToken(true);
+            const res = await fetch('/api/v1/team/delete', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'Authorization': `Bearer ${idToken}`,
+                },
+                body: JSON.stringify({team_id: form.team_id}),
+            });
+
+            if (res.ok) {
+                setTeam(null);
+                setProfile({...profile, team_id: ''});
+                setLeave(true);
+
+            } else {
+                const errorData = await res.json();
+                console.log(errorData.error || 'Failed to remove team');
+            }
+        } catch (error) {
+            console.error('Error removing from team:', error);
+            console.log('An error occurred while removing from the team');
+        } finally {
+            setIsLeaving(false);
+
+            // Clear any existing timer
+            if (leaveTimer) {
+                clearTimeout(leaveTimer);
+            }
+
+            // Set delay for leaving state with proper cleanup
+            const timer = setTimeout(() => {
+                setLeave(false);
+                setLeaveTimer(null);
+                // Refresh the page to show updated state instead of router.push
+                window.location.reload();
+            }, 2000);
+
+            setLeaveTimer(timer);
+        }
+    }
+
+    useEffect(() => {
+        if (team) {
+            setIsFormLoading(true);
+            const timer = setTimeout(() => {
+                setForm({
+                    team_id: team.team_id || '',
+                    team_name: team.team_name || '',
+                    team_leader: team.team_leader || '',
+                    peers: (team.peers as Array<{ id: string; name: string }>) || [],
+                    drive_link: team.drive_link || '',
+                });
+                setIsFormLoading(false);
+            }, 1);
+            return () => clearTimeout(timer);
+        }
+    }, [team]);
+
+    const handleLeaveTeam = async () => {
+        if (!user) return;
+
+        setIsLeaving(true);
+
+        try {
+            const idToken = await user.getIdToken(true);
+            const res = await fetch('/api/v1/team/leave', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'Authorization': `Bearer ${idToken}`,
+                },
+                body: JSON.stringify({team_id: form.team_id}),
+            });
+
+            if (res.ok) {
+                setTeam(null);
+                setProfile({...profile, team_id: ''});
+
+                // Set leave state to show success message
+                setLeave(true);
+
+            } else {
+                const errorData = await res.json();
+                console.log(errorData.error || 'Failed to leave team');
+            }
+        } catch (error) {
+            console.error('Error leaving team:', error);
+            console.log('An error occurred while leaving the team');
+        } finally {
+            setIsLeaving(false);
+
+            // Clear any existing timer
+            if (leaveTimer) {
+                clearTimeout(leaveTimer);
+            }
+
+            // Set delay for leaving state with proper cleanup
+            const timer = setTimeout(() => {
+                setLeave(false);
+                setLeaveTimer(null);
+                // Refresh the page to show updated state instead of router.push
+                window.location.reload();
+            }, 2000);
+
+            setLeaveTimer(timer);
+        }
+    }
+
+    // Cleanup timer on component unmount
+    useEffect(() => {
+        return () => {
+            if (leaveTimer) {
+                clearTimeout(leaveTimer);
+            }
+        };
+    }, [leaveTimer]);
+
+    const displayButtons = () => {
+        return (
+            <div className="flex items-center justify-between mb-6 bg-white rounded-lg shadow p-8 gap-5">
+                <Button className="bg-black hover:bg-black/70 text-white" asChild><Link href="/profile/hackathon/join">Join a Team</Link></Button>
+                <Button className="bg-black hover:bg-black/70 text-white" asChild><Link href="/profile/hackathon/create">Create a Team</Link></Button>
+            </div>
+        );
+    }
+
+    const displayTeamLeader = () => {
+        return (
+            <div className="flex flex-col items-center justify-between mb-6 bg-white rounded-lg shadow p-8 gap-5 text-gray-900">
+                <h1 className="text-2xl font-bold text-gray-900">Profile</h1>
+                <Label>Team ID: {form.team_id}</Label>
+                <Label>Team Name: {form.team_name}</Label>
+                <Label>Team Leader: {form.team_leader}</Label>
+                <div className="w-full">
+                    <Label>Peers:</Label>
+                    <div className="mt-2 w-full space-y-2">
+                        {form.peers && form.peers.length > 0 ? (
+                            form.peers.map((peer) => (
+                                <div key={peer.id} className="flex items-center justify-between w-full border rounded-md px-3 py-2">
+                                    <div className="flex flex-col">
+                                        <span className="text-sm text-gray-800">{peer.name}</span>
+                                        <span className="text-xs text-gray-500">{peer.id}</span>
+                                    </div>
+                                    <Button className="bg-red-600 text-white" size="sm" onClick={() => handleRemovePeer(peer.id, peer.name)}>
+                                        {isLeaving ? 'Removing...' : leave ? 'Removed!' : 'Remove'}
+                                    </Button>
+                                </div>
+                            ))
+                        ) : (
+                            <span className="text-sm text-gray-500">No peers added</span>
+                        )}
+                    </div>
+                </div>
+                <Label>Drive Link: {form.drive_link || 'Not provided'}</Label>
+                {/* Show Delete Team button only when there are zero peers */}
+                {form.peers && form.peers.length === 0 ? (
+                    <Button className="bg-red-600 text-white mt-2" onClick={handleDeleteTeam}>
+                        {isLeaving ? 'Deleting...' : leave ? 'Deleted!' : 'Delete Team'}
+                    </Button>
+                ) : null}
+            </div>
+        )
+    }
+
+    const displayTeamMember = () => {
+        return (
+            <div className="flex flex-col items-center justify-between mb-6 bg-white rounded-lg shadow p-8 gap-5 text-gray-900">
+                <h1 className="text-2xl font-bold text-gray-900">Profile</h1>
+                <Label>Team ID: {form.team_id}</Label>
+                <Label>Team Name: {form.team_name}</Label>
+                <Label>Team Leader: {form.team_leader}</Label>
+                <Label>
+                    Peers: {form.peers.length > 0 ? form.peers.map(peer => peer.name).join(', ') : 'No peers added'}
+                </Label>
+                <Label>Drive Link: {form.drive_link || 'Not provided'}</Label>
+                {form.team_id !== user?.uid ? <Button className="cursor-pointer" onClick={handleLeaveTeam}>
+                    {isLeaving ? 'Leaving...' : leave ? 'Left!': 'Leave'}
+                </Button> : null}
+            </div>
+        )
+    }
+
+    if (loading || teamLoading || isFormLoading) {
+        return (
+            <div className="min-h-screen flex items-center justify-center bg-gray-50">
+                <div className="text-center">
+                    <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600 mx-auto"></div>
+                    <p className="mt-4 text-gray-600">
+                        {loading || teamLoading ? 'Loading...' : 'Preparing team...'}
+                    </p>
+                </div>
+            </div>
+        );
+    }
+
   return (
-    <div className="flex flex-col items-center justify-center min-h-screen p-4">
-      <h1 className="text-2xl font-bold mb-4">Hackathon Page</h1>
-      <p className="text-lg">This is the hackathon page content.</p>
-      {/* Add your hackathon related components here */}
+    <div className="flex flex-col items-center justify-center min-h-screen p-4 bg-gray-50">
+        {form.team_id !== "" ? (form.team_id === user?.uid ? displayTeamLeader() : displayTeamMember()) : displayButtons()}
     </div>
   );
 }

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -13,10 +13,11 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
+import Link from "next/link";
 
 export default function ProfilePage() {
   const router = useRouter();
-  const { user, loading, signOut, profile, profileLoading, setProfile } = useAuth();
+  const { user, loading, signOut, profile, profileLoading, setProfile, team, teamLoading, setTeam } = useAuth();
 
   const [form, setForm] = useState({
     name: '',
@@ -97,6 +98,12 @@ export default function ProfilePage() {
 
       if (res.ok) {
         const data = await res.json();
+
+        // If API indicates we should refresh token, force refresh to get updated claims
+        if (data.refreshToken) {
+          await user.getIdToken(true);
+        }
+
         setProfile(data.user);
         setSaved(true);
         setIsDirty(false);
@@ -254,7 +261,7 @@ export default function ProfilePage() {
           </form>
         </div>
       </div>
-      <Button>Hackathon</Button>
+      <Button asChild><Link href="/profile/hackathon">Hackathon</Link></Button>
     </div>
   );
 }


### PR DESCRIPTION
Edits I made,
1. Add endpoints create, join, remove, leave, get and delete team as their respective hackathon team features
2. Add a minimal frontend to them for basic working worflow
3. Made changes to AuthContext to add support for hackathon teams alongside user profile
4. Added a button in the profile page that re-directs to a dedicated hackathon page